### PR TITLE
Update execution metrics units

### DIFF
--- a/backend/app/executor.py
+++ b/backend/app/executor.py
@@ -32,8 +32,8 @@ class ExecutionResult(BaseModel):
     stdout: str
     stderr: str
     exitCode: int
-    duration: float
-    memoryUsed: int
+    duration: float  # milliseconds
+    memoryUsed: int  # kilobytes
     timedOut: bool
 
 
@@ -154,7 +154,7 @@ async def run_code(
         stdout, stderr = await process.communicate()
         timed_out = True
 
-    duration = time.perf_counter() - start
+    duration = (time.perf_counter() - start) * 1000  # ms
     exit_code = process.returncode if process.returncode is not None else -1
     peak_rss = await mem_task
 
@@ -164,7 +164,7 @@ async def run_code(
         stderr=stderr.decode(),
         exitCode=exit_code,
         duration=duration,
-        memoryUsed=int(peak_rss / (1024 * 1024)),
+        memoryUsed=int(peak_rss / 1024),
         timedOut=timed_out,
     )
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -17,7 +17,7 @@ function displayResults(data) {
     const met = data
       .map(
         (r, i) =>
-          `#${i + 1} exitCode: ${r.exitCode}, duration: ${r.duration.toFixed(3)}s, memory: ${r.memoryUsed}MB, timedOut: ${r.timedOut}`
+          `#${i + 1} exitCode: ${r.exitCode}, duration: ${r.duration.toFixed(0)}ms, memory: ${r.memoryUsed}KB, timedOut: ${r.timedOut}`
       )
       .join("\n");
     document.getElementById("stdout").textContent = out;
@@ -27,8 +27,8 @@ function displayResults(data) {
     document.getElementById("stdout").textContent = data.stdout || "";
     document.getElementById("stderr").textContent = data.stderr || "";
     document.getElementById("metrics").textContent =
-      `exitCode: ${data.exitCode}, duration: ${data.duration.toFixed(3)}s, ` +
-      `memory: ${data.memoryUsed}MB, timedOut: ${data.timedOut}`;
+      `exitCode: ${data.exitCode}, duration: ${data.duration.toFixed(0)}ms, ` +
+      `memory: ${data.memoryUsed}KB, timedOut: ${data.timedOut}`;
   }
 }
 

--- a/online_judge_backend/app/executor.py
+++ b/online_judge_backend/app/executor.py
@@ -32,8 +32,8 @@ class ExecutionResult(BaseModel):
     stdout: str
     stderr: str
     exitCode: int
-    duration: float
-    memoryUsed: int
+    duration: float  # milliseconds
+    memoryUsed: int  # kilobytes
     timedOut: bool
 
 
@@ -154,7 +154,7 @@ async def run_code(
         stdout, stderr = await process.communicate()
         timed_out = True
 
-    duration = time.perf_counter() - start
+    duration = (time.perf_counter() - start) * 1000  # ms
     exit_code = process.returncode if process.returncode is not None else -1
     peak_rss = await mem_task
 
@@ -164,7 +164,7 @@ async def run_code(
         stderr=stderr.decode(),
         exitCode=exit_code,
         duration=duration,
-        memoryUsed=int(peak_rss / (1024 * 1024)),
+        memoryUsed=int(peak_rss / 1024),
         timedOut=timed_out,
     )
 

--- a/online_judge_backend/docs/API.ko.md
+++ b/online_judge_backend/docs/API.ko.md
@@ -38,14 +38,14 @@
     "stdout": "output",
     "stderr": "",
     "exitCode": 0,
-    "duration": 0.12,
-    "memoryUsed": 12,
+    "duration": 120,
+    "memoryUsed": 12288,
     "timedOut": false
   }
 ]
 ```
-- `duration`: 실행 시간(초)
-- `memoryUsed`: 사용한 메모리(MB)
+- `duration`: 실행 시간(ms)
+- `memoryUsed`: 사용한 메모리(KB)
 - 지원하지 않는 언어일 경우 `501 Not Implemented`
 - 잘못된 요청 등 기타 오류 시 `400 Bad Request`
 


### PR DESCRIPTION
## Summary
- change `ExecutionResult` to report duration in milliseconds and memory in KB
- adjust executor implementations for new units
- update API docs and frontend text to show new units

## Testing
- `python -m py_compile backend/app/executor.py online_judge_backend/app/executor.py backend/app/main.py online_judge_backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d22a2cd80832eabd1f2aa178d33f2