### PR TITLE
Ensure .env loading across async backend modules

### DIFF
--- a/online_judge_backend/app/rabbitmq_rpc.py
+++ b/online_judge_backend/app/rabbitmq_rpc.py
@@ -3,7 +3,13 @@ import json
 import os
 import uuid
 
+from pathlib import Path
+from dotenv import load_dotenv
 import aio_pika
+
+# Load ../.env relative to this file so it works regardless of cwd
+env_path = Path(__file__).resolve().parents[2] / ".env"
+load_dotenv(dotenv_path=env_path)
 
 
 class RpcClient:

--- a/online_judge_backend/app/worker.py
+++ b/online_judge_backend/app/worker.py
@@ -2,7 +2,13 @@ import asyncio
 import json
 import os
 
+from pathlib import Path
+from dotenv import load_dotenv
 import aio_pika
+
+# Load ../.env relative to this file so it works regardless of cwd
+env_path = Path(__file__).resolve().parents[2] / ".env"
+load_dotenv(dotenv_path=env_path)
 
 from .executor import execute_code_multiple, SupportedLanguage
 


### PR DESCRIPTION
## Summary
- load `.env` with a fixed path in `rabbitmq_rpc.py`
- load `.env` with a fixed path in `worker.py`

## Testing
- `python -m py_compile online_judge_backend/app/rabbitmq_rpc.py online_judge_backend/app/worker.py`
- `python -m py_compile backend/app/executor.py online_judge_backend/app/executor.py`


------
https://chatgpt.com/codex/tasks/task_e_685d5cb43d9c832eb80b26569aeb81ac