### PR TITLE
Add env var docs for AWS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.log
+*.tmp
+*.temp
+online_judge_backend/venv
+backend/venv
+frontend/node_modules
+frontend/dist
+frontend/build
+.git
+.gitignore

--- a/Dockerfile.online-judge.backend
+++ b/Dockerfile.online-judge.backend
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY online_judge_backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+COPY online_judge_backend ./online_judge_backend
+CMD ["uvicorn", "online_judge_backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.online-judge.worker
+++ b/Dockerfile.online-judge.worker
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY online_judge_backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+COPY online_judge_backend ./online_judge_backend
+CMD ["python", "-m", "online_judge_backend.app.worker"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -59,7 +59,7 @@ python -m http.server 8080
 ```
 이후 `http://localhost:8080`에 접속합니다.
 
-프론트엔드에는 API 주소를 입력할 수 있는 필드가 있습니다. 기본값은 `http://localhost:8000`으로 FastAPI 백엔드를 가리킵니다. 다른 서버를 지정하는 경우 CORS 설정이 되어 있어야 합니다.
+프론트엔드에는 API 주소를 입력할 수 있는 필드가 있습니다. 기본값은 `http://localhost:8000`으로 FastAPI 백엔드를 가리킵니다. 다른 서버를 지정하는 경우 CORS 설정이 되어 있어야 합니다. 추가 오리진은 `.env` 파일의 `CORS_ALLOW_ORIGINS` 변수(콤마 구분)를 통해 지정할 수 있습니다.
 
 ## 사용법
 JWT 토큰을 입력한 뒤 언어와 코드를 작성하고 STDIN이 있다면 빈 줄로 구분된 블록 단위로 입력할 수 있습니다. 한 블록은 여러 줄을 포함할 수 있으며, 빈 줄이 나타날 때마다 다음 실행으로 인식됩니다. **실행!** 버튼을 누르면 각 블록에 대해 코드를 실행한 결과 배열을 돌려줍니다.
@@ -69,6 +69,32 @@ REST API의 세부 규격은 [online_judge_backend/docs/API.ko.md](online_judge_
 
 ## RabbitMQ 관련
 이 코드베이스는 **RabbitMQ 서버 기반 비동기 처리**를 상정하여 구성되었습니다. [online_judge_backend/docs/RabbitMQ.ko.md](online_judge_backend/docs/RabbitMQ.ko.md) 파일을 참고하세요.
+
+## Docker 이미지 빌드 및 ECR 푸시
+백엔드용 `Dockerfile.online-judge.backend`와 워커용 `Dockerfile.online-judge.worker`가 제공됩니다.
+
+### 백엔드 이미지 빌드
+
+```bash
+docker build -f Dockerfile.online-judge.backend -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest .
+```
+
+### 워커 이미지 빌드
+
+```bash
+docker build -f Dockerfile.online-judge.worker -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest .
+```
+
+### ECR에 푸시
+
+```bash
+aws ecr get-login-password --region <REGION> | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest
+docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest
+```
+
+## AWS 환경에서 환경 변수 설정
+`CORS_ALLOW_ORIGINS`를 포함한 `.env.example`에 정의된 값들은 ECS 작업 정의의 **Environment variables** 항목에서 지정할 수 있습니다. AWS 콘솔에서 수정하거나 `aws ecs register-task-definition` 명령을 통해 등록할 때 환경 변수를 함께 전달하면 됩니다.
 
 ## 라이선스
 이 저장소에는 별도의 라이선스 파일이 포함되어 있지 않습니다.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ python -m http.server 8080
 ```
 Then visit `http://localhost:8080`.
 
-The frontend includes a field to specify the API URL. The default is `http://localhost:8000`, which points to the FastAPI backend. If specifying a different server, make sure CORS settings are configured properly.
+The frontend includes a field to specify the API URL. The default is `http://localhost:8000`, which points to the FastAPI backend. If specifying a different server, make sure CORS settings are configured properly. Additional origins can be added via the `CORS_ALLOW_ORIGINS` variable in the `.env` file (comma-separated).
 
 ## Usage
 After entering a JWT token, select a language and write your code. If there is STDIN input, enter it as blocks separated by blank lines. Each block can contain multiple lines, and a new execution is triggered when a blank line is encountered. Press the **Execute!** button to receive an array of results, one per input block.
@@ -68,6 +68,32 @@ Refer to the [online_judge_backend/docs/API.ko.md](online_judge_backend/docs/API
 
 ## Asynchronous Processing with RabbitMQ Server
 This codebase is designed with **asynchronous processing based on a RabbitMQ server** in mind. See the [online_judge_backend/docs/RabbitMQ.ko.md](online_judge_backend/docs/API.ko.md) file for more information.
+
+## Building Docker Images for AWS ECR
+Two Dockerfiles are provided for running the backend and worker on ECS/Fargate.
+
+Build the backend image:
+
+```bash
+docker build -f Dockerfile.online-judge.backend -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest .
+```
+
+Build the worker image:
+
+```bash
+docker build -f Dockerfile.online-judge.worker -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest .
+```
+
+Push images to ECR (after logging in):
+
+```bash
+aws ecr get-login-password --region <REGION> | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest
+docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest
+```
+
+## Configuring Environment Variables on AWS
+You can define environment variables such as `CORS_ALLOW_ORIGINS`, `FAAS_BASE_URL`, `FAAS_TOKEN`, and `RABBITMQ_URL` in your ECS task definition. In the AWS console, open the task definition and add them under **Environment variables**. These can also be specified when registering the task definition using the AWS CLI.
 
 ## License
 This repository does not include a separate license file.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,18 +10,26 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from .executor import execute_code, SupportedLanguage, ExecutionResult
+import os
 
 app = FastAPI()
 
-# CORS 설정 (필요에 따라 origins 수정)
-# allow requests from any origin (use env vars to restrict in production)
+# CORS 설정
+# 기본 오리진 목록에 환경 변수를 통해 추가 오리진을 지정할 수 있다.
+origins = [
+    "http://localhost",
+    "http://localhost:3000",
+    "http://localhost:8080",
+    "http://localhost:8000",
+]
+
+extra_origins = os.getenv("CORS_ALLOW_ORIGINS")
+if extra_origins:
+    origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-    "http://localhost",
-    "http://localhost:3000", # 배포 시 프론트엔드 주소 - maybe?
-    "http://localhost:8080", # 배포 시 프론트엔드 주소 - maybe?
-    "http://localhost:8000", ],
+    allow_origins=origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/online_judge_backend/.env.example
+++ b/online_judge_backend/.env.example
@@ -2,3 +2,5 @@
 FAAS_BASE_URL=https://api.example.com/api/v1
 FAAS_TOKEN=
 RABBITMQ_URL=amqp://admin:password@localhost:5672/
+# Comma-separated list of additional CORS origins
+CORS_ALLOW_ORIGINS=

--- a/online_judge_backend/app/main.py
+++ b/online_judge_backend/app/main.py
@@ -24,15 +24,22 @@ load_dotenv(dotenv_path=env_path, override=False)
 
 app = FastAPI()
 
-# CORS 설정 (필요에 따라 origins 수정)
-# allow requests from any origin (use env vars to restrict in production)
+# CORS 설정
+# 기본 오리진 목록을 환경 변수로 확장할 수 있다.
+origins = [
+    "http://localhost",
+    "http://localhost:3000",
+    "http://localhost:8080",
+    "http://localhost:8000",
+]
+
+extra_origins = os.getenv("CORS_ALLOW_ORIGINS")
+if extra_origins:
+    origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-    "http://localhost",
-    "http://localhost:3000", # 배포 시 프론트엔드 주소 - maybe?
-    "http://localhost:8080", # 배포 시 프론트엔드 주소 - maybe?
-    "http://localhost:8000", ],
+    allow_origins=origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- mention environment variable config for ECS/Fargate in READMEs

## Testing
- `python -m compileall -q online_judge_backend/app`
- `python -m compileall -q backend/app`


------
https://chatgpt.com/codex/tasks/task_e_685f7ca4a51c832ea275f7765caf29a4