### PR TITLE
Set timezone and add compilers

### DIFF
--- a/Dockerfile.online-judge.backend
+++ b/Dockerfile.online-judge.backend
@@ -1,4 +1,11 @@
 FROM python:3.11-slim
+
+ENV TZ=Asia/Seoul
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY online_judge_backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Dockerfile.online-judge.worker
+++ b/Dockerfile.online-judge.worker
@@ -1,4 +1,11 @@
 FROM python:3.11-slim
+
+ENV TZ=Asia/Seoul
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata build-essential openjdk-17-jdk && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY online_judge_backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
## Summary
- set timezone to Asia/Seoul in both Dockerfiles
- install build tools and JDK in worker image

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f8bd6d09c832e919f8d3333e02c61