### PR TITLE
Set timezone and add compilers

### DIFF
--- a/Dockerfile.online-judge.backend
+++ b/Dockerfile.online-judge.backend
@@ -1,4 +1,11 @@
 FROM python:3.11-slim
+
+ENV TZ=Asia/Seoul
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY online_judge_backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/Dockerfile.online-judge.worker
+++ b/Dockerfile.online-judge.worker
@@ -1,4 +1,11 @@
 FROM python:3.11-slim
+
+ENV TZ=Asia/Seoul
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata build-essential openjdk-17-jdk && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY online_judge_backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/README.ko.md
+++ b/README.ko.md
@@ -70,31 +70,10 @@ REST API의 세부 규격은 [online_judge_backend/docs/API.ko.md](online_judge_
 ## RabbitMQ 관련
 이 코드베이스는 **RabbitMQ 서버 기반 비동기 처리**를 상정하여 구성되었습니다. [online_judge_backend/docs/RabbitMQ.ko.md](online_judge_backend/docs/RabbitMQ.ko.md) 파일을 참고하세요.
 
-## Docker 이미지 빌드 및 ECR 푸시
-백엔드용 `Dockerfile.online-judge.backend`와 워커용 `Dockerfile.online-judge.worker`가 제공됩니다.
-
-### 백엔드 이미지 빌드
-
-```bash
-docker build -f Dockerfile.online-judge.backend -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest .
-```
-
-### 워커 이미지 빌드
-
-```bash
-docker build -f Dockerfile.online-judge.worker -t <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest .
-```
-
-### ECR에 푸시
-
-```bash
-aws ecr get-login-password --region <REGION> | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
-docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest
-docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest
-```
-
-## AWS 환경에서 환경 변수 설정
-`CORS_ALLOW_ORIGINS`를 포함한 `.env.example`에 정의된 값들은 ECS 작업 정의의 **Environment variables** 항목에서 지정할 수 있습니다. AWS 콘솔에서 수정하거나 `aws ecs register-task-definition` 명령을 통해 등록할 때 환경 변수를 함께 전달하면 됩니다.
+## AWS 배포
+AWS ECR/ECS Fargate에 이미지를 배포하고 환경 변수를 설정하는 방법은
+[online_judge_backend/docs/AWS_Deploy.ko.md](online_judge_backend/docs/AWS_Deploy.ko.md)
+문서를 참고하세요.
 
 ## 라이선스
 이 저장소에는 별도의 라이선스 파일이 포함되어 있지 않습니다.

--- a/online_judge_backend/docs/AWS_Deploy.ko.md
+++ b/online_judge_backend/docs/AWS_Deploy.ko.md
@@ -1,0 +1,55 @@
+# AWS ECR/ECS Fargate 배포 가이드
+
+이 문서는 온라인 저지 백엔드와 워커 이미지를 AWS ECR과 ECS Fargate에 배포해
+필요할 때만 컨테이너를 실행하는, 이른바 "scale-to-zero"에 가까운 구조를 구성하는
+방법을 안내합니다. 특별한 AWS 경험이 없는 IT 기획자 분들도 따라 할 수 있도록
+단계별로 정리했습니다.
+
+## 1. ECR 저장소 준비와 이미지 푸시
+1. AWS 콘솔에서 **ECR** 서비스로 이동하여 백엔드용과 워커용 두 개의
+   리포지토리를 생성합니다.
+2. 로컬 PC 또는 CI 환경에서 아래 명령으로 이미지를 빌드합니다.
+
+```bash
+docker build -f Dockerfile.online-judge.backend -t \
+  <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest .
+
+docker build -f Dockerfile.online-judge.worker -t \
+  <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest .
+```
+3. 빌드가 끝나면 ECR에 로그인 후 이미지를 푸시합니다.
+
+```bash
+aws ecr get-login-password --region <REGION> | \
+  docker login --username AWS --password-stdin \
+  <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+
+docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-backend:latest
+docker push <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/online-judge-worker:latest
+```
+
+## 2. ECS Fargate 작업 정의와 서비스 생성
+1. **ECS → Task Definitions** 메뉴에서 Fargate를 선택해 작업 정의를 만듭니다.
+2. 컨테이너 이미지에는 위에서 푸시한 ECR 이미지를 지정합니다.
+3. 같은 화면에서 **Environment variables** 항목에 다음과 같이
+   `.env.example`에서 사용한 변수들을 입력할 수 있습니다.
+   - `RABBITMQ_URL`
+   - `CORS_ALLOW_ORIGINS`
+   - `FAAS_BASE_URL`
+   - `FAAS_TOKEN`
+4. 필요한 CPU/메모리 값을 입력하고 작업 정의를 저장합니다.
+5. 생성한 작업 정의로 **Service**를 만들면 Fargate에서 컨테이너가 실행됩니다.
+
+## 3. Scale-to-zero 구현 힌트
+- ECS 서비스의 원하는 실행 개수(`Desired count`)를 0으로 변경하면 컨테이너가
+  모두 중지되어 비용을 최소화할 수 있습니다.
+- AWS 콘솔에서 수동으로 값을 0으로 수정하거나,
+  `aws ecs update-service --cluster <CLUSTER> --service <SERVICE> --desired-count 0`
+  명령으로 스크립트화할 수 있습니다.
+- CloudWatch Events(또는 EventBridge) 스케줄러를 이용해 야간에 자동으로 0으로
+  줄이고 필요 시 다시 1 이상으로 늘리는 방식으로 "거의" scale-to-zero 효과를
+  얻을 수 있습니다.
+
+## 4. 추가 팁
+- 로그는 CloudWatch Logs로 수집되므로, 오류 발생 시 해당 로그 그룹을 확인하세요.
+- 이후 EKS로 이전하더라도 ECR 이미지는 그대로 사용할 수 있습니다.


### PR DESCRIPTION
## Summary
- set timezone to Asia/Seoul in both Dockerfiles
- install build tools and JDK in worker image
- document how to deploy with AWS ECR/ECS
- point README.ko.md to the deployment guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685f8bd6d09c832e919f8d3333e02c61