### PR TITLE
Add progress bar to v2 frontend

### DIFF
--- a/frontend/app_v2.js
+++ b/frontend/app_v2.js
@@ -33,6 +33,7 @@ function displayResults(data) {
 function updateProgress(completed) {
   const percent = Math.min(100, (completed / totalRuns) * 100);
   document.getElementById("progressBar").style.width = `${percent}%`;
+  document.getElementById("progressLabel").textContent = `${percent.toFixed(0)}%`;
 }
 
 /**

--- a/frontend/index_v2.html
+++ b/frontend/index_v2.html
@@ -52,6 +52,7 @@
   <h2>결과</h2>
   <div id="progressContainer" class="progress-container">
     <div id="progressBar" class="progress-bar"></div>
+    <span id="progressLabel" class="progress-label">0%</span>
   </div>
   <p id="judgeMessage"></p>
   <pre id="stdout"></pre>

--- a/frontend/index_v2.html
+++ b/frontend/index_v2.html
@@ -50,6 +50,10 @@
   <button id="run">실행!</button>
 
   <h2>결과</h2>
+  <div id="progressContainer" class="progress-container">
+    <div id="progressBar" class="progress-bar"></div>
+  </div>
+  <p id="judgeMessage"></p>
   <pre id="stdout"></pre>
   <pre id="stderr" class="error"></pre>
   <p id="metrics"></p>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -52,6 +52,8 @@ pre.error {
   border-radius: 4px;
   overflow: hidden;
   margin-top: 10px;
+  position: relative;
+  border: 1px solid #ccc;
 }
 
 .progress-bar {
@@ -59,6 +61,15 @@ pre.error {
   width: 0%;
   background: #4caf50;
   transition: width 0.2s;
+}
+
+.progress-label {
+  position: absolute;
+  width: 100%;
+  top: 0;
+  text-align: center;
+  line-height: 20px;
+  font-size: 12px;
 }
 
 #judgeMessage {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -44,3 +44,24 @@ pre {
 pre.error {
   color: red;
 }
+
+.progress-container {
+  width: 100%;
+  background: #eee;
+  height: 20px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-top: 10px;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0%;
+  background: #4caf50;
+  transition: width 0.2s;
+}
+
+#judgeMessage {
+  font-weight: bold;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- show execution progress when using the v2 frontend
- add styles for the progress bar and judge message
- report overall success/failure of executed code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860e6485628832eb03969b11d7a97ce