### PR TITLE
Update docs for execute_v3

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,10 +1,10 @@
 # Codeground 온라인 저지
 
-이 프로젝트는 클라이언트로부터 `POST /execute` 요청을 받아 코드를 컴파일 및 실행하여 `stdout`, `stderr`, 실행 시간, 총 메모리 사용량 등을 리턴하는 온라인 저지로, 데모용 프론트엔드 (`frontend`), FastAPI 백엔드 (`online_judge_backend\app\main.py`), 그리고 워커 프로세스 (`online_judge_backend\app\worker.py`)로 구성되어 있습니다. `backend` 폴더는 추후 삭제 예정이므로 무시해주세요.
+이 프로젝트는 클라이언트로부터 HTTP 요청을 받아 코드를 실행하고 채점 결과를 제공하는 온라인 저지입니다. 데모용 프론트엔드(`frontend`), FastAPI 백엔드(`online_judge_backend/app/main.py`), 그리고 워커 프로세스(`online_judge_backend/app/worker.py`)로 구성되어 있습니다. `backend` 폴더는 추후 삭제 예정이므로 무시해주세요.
 
 - Python, Java, C, C++ 코드를 실행
 - 지원하지 않는 언어는 **501 Not Implemented** 응답
-- 백엔드(`online_judge_backend` 폴더)는 FastAPI 기반 `/execute` API를 제공하며 RabbitMQ로 작업을 워커에 전달합니다.
+- 백엔드(`online_judge_backend` 폴더)는 FastAPI 기반 `/execute` API 외에도 `/execute_v2`, `/execute_v3` 엔드포인트를 제공하며 RabbitMQ로 작업을 워커에 전달합니다.
 - 워커는 `python -m online_judge_backend.app.worker` 명령으로 실행합니다.
 - 프론트엔드(`frontend` 폴더)는 백엔드를 사용할 수 있는 데모 웹 UI입니다.
 
@@ -66,13 +66,15 @@ python -m http.server 8080
 
 클라이언트는 테스트 케이스 수를 미리 알 수 없으므로 각 `progress` 메시지에는 전체 개수를 나타내는 `total` 값이 포함됩니다. 테스트 케이스가 하나라도 실패하면 남은 케이스는 실행하지 않고 즉시 결과가 전송됩니다. `/execute_v3`의 HTTP 응답에는 `requestId`만 포함되며 최종 채점 결과는 WebSocket 메시지로 전달됩니다.
 
+문제 정의는 `online_judge_backend/static/codeground-problems` 폴더의 JSON 파일로 관리됩니다. 각 파일에는 테스트 케이스와 제한 사항이 담겨 있으며 `/execute_v3`에서 사용됩니다.
+
 프론트엔드에는 API 주소를 입력할 수 있는 필드가 있습니다. 기본값은 `http://localhost:8000`으로 FastAPI 백엔드를 가리킵니다. 다른 서버를 지정하는 경우 CORS 설정이 되어 있어야 합니다. 추가 오리진은 `.env` 파일의 `CORS_ALLOW_ORIGINS` 변수(콤마 구분)를 통해 지정할 수 있습니다.
 
 ## 사용법
 JWT 토큰을 입력한 뒤 언어와 코드를 작성하고 STDIN이 있다면 빈 줄로 구분된 블록 단위로 입력할 수 있습니다. 한 블록은 여러 줄을 포함할 수 있으며, 빈 줄이 나타날 때마다 다음 실행으로 인식됩니다. **실행!** 버튼을 누르면 각 블록에 대해 코드를 실행한 결과 배열을 돌려줍니다.
 
 ## REST API 명세
-REST API의 세부 규격은 [online_judge_backend/docs/API.ko.md](online_judge_backend/docs/API.ko.md) 파일을 참고하세요.
+REST API의 세부 규격은 [online_judge_backend/docs/API.ko.md](online_judge_backend/docs/API.ko.md) 파일을 참고하세요. 간단한 영어 버전은 `API.md`에서 확인할 수 있습니다.
 
 ## RabbitMQ 관련
 이 코드베이스는 **RabbitMQ 서버 기반 비동기 처리**를 상정하여 구성되었습니다. [online_judge_backend/docs/RabbitMQ.ko.md](online_judge_backend/docs/RabbitMQ.ko.md) 파일을 참고하세요.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [한국어 README](README.ko.md)
 
-An interface that allows you to execute code via a simple `/execute` API.
+- An interface that allows you to execute code via several HTTP endpoints.
 
 - Executes Python, Java, C, and C++ code
 - Returns **501 Not Implemented** for unsupported languages
-- The backend (in the `online_judge_backend` folder) provides the `/execute` API using FastAPI and
-  delivers jobs to workers via RabbitMQ.
+- The backend (in the `online_judge_backend` folder) exposes `/execute` for synchronous
+  runs and `/execute_v2`/`/execute_v3` for asynchronous processing. Jobs are delivered
+  to workers via RabbitMQ.
 - Workers can be started with the command `python -m online_judge_backend.app.worker`.
 - The frontend (in the `frontend` folder) is a demo web UI that utilizes the backend.
 
@@ -70,16 +71,20 @@ and the final graded result is returned immediately. The HTTP response only
 contains a `requestId` and the final graded result is delivered via the
 WebSocket.
 
+Problem definitions are stored as JSON under
+`online_judge_backend/static/codeground-problems`. Each file lists the test cases
+and limits used by `/execute_v3`.
+
 The frontend includes a field to specify the API URL. The default is `http://localhost:8000`, which points to the FastAPI backend. If specifying a different server, make sure CORS settings are configured properly. Additional origins can be added via the `CORS_ALLOW_ORIGINS` variable in the `.env` file (comma-separated).
 
 ## Usage
 After entering a JWT token, select a language and write your code. If there is STDIN input, enter it as blocks separated by blank lines. Each block can contain multiple lines, and a new execution is triggered when a blank line is encountered. Press the **Execute!** button to receive an array of results, one per input block.
 
 ## REST API Specification
-Refer to the [online_judge_backend/docs/API.ko.md](online_judge_backend/docs/API.ko.md) file for detailed REST API specifications.
+Refer to [online_judge_backend/docs/API.md](online_judge_backend/docs/API.md) for an overview of the REST API. A more detailed Korean version is available at `API.ko.md`.
 
 ## Asynchronous Processing with RabbitMQ Server
-This codebase is designed with **asynchronous processing based on a RabbitMQ server** in mind. See the [online_judge_backend/docs/RabbitMQ.ko.md](online_judge_backend/docs/API.ko.md) file for more information.
+This codebase is designed with **asynchronous processing based on a RabbitMQ server** in mind. See [online_judge_backend/docs/RabbitMQ.ko.md](online_judge_backend/docs/RabbitMQ.ko.md) for more information.
 
 ## Building Docker Images for AWS ECR
 Two Dockerfiles are provided for running the backend and worker on ECS/Fargate.

--- a/online_judge_backend/docs/API.md
+++ b/online_judge_backend/docs/API.md
@@ -1,0 +1,68 @@
+# Online Judge Backend REST API
+
+This document describes the HTTP API provided by the backend. There are three main endpoints:
+
+- `POST /execute` &ndash; run code synchronously.
+- `POST /execute_v2` &ndash; run code asynchronously and stream progress through WebSockets.
+- `POST /execute_v3` &ndash; grade code against predefined problems. Progress is streamed as with `/execute_v2`.
+
+For websocket updates, connect to `/ws/progress/{requestId}` using the `requestId` returned by the `v2` or `v3` endpoints.
+
+## POST `/execute`
+
+```json
+{
+  "language": "python",
+  "code": "print(input())",
+  "stdins": ["1"],
+  "timeLimit": 30000,
+  "memoryLimit": 256,
+  "token": null
+}
+```
+
+Responds with an array of execution results, one per item in `stdins`.
+
+## POST `/execute_v2`
+
+Uses the same request body as `/execute` but returns immediately with a `requestId`. Connect to `/ws/progress/{requestId}` to receive progress and the final results.
+
+```json
+{
+  "requestId": "UUID"
+}
+```
+
+## POST `/execute_v3`
+
+Grades the given code against the problem specified by `problemId`. Test case data is read from `static/codeground-problems/{problemId}.json`.
+
+```json
+{
+  "language": "python",
+  "code": "print(input())",
+  "problemId": "prob-001",
+  "token": null
+}
+```
+
+The HTTP response contains only a `requestId`. WebSocket messages include `progress` events for each test case and a final message:
+
+```json
+{
+  "type": "final",
+  "problemId": "prob-001",
+  "allPassed": true,
+  "results": [
+    {
+      "id": 1,
+      "visibility": "public",
+      "passed": true,
+      "stdout": "2",
+      "expected": "2"
+    }
+  ]
+}
+```
+
+Each `progress` message contains `index`, `result` and `total` fields so the client can update progress bars.


### PR DESCRIPTION
## Summary
- mention new /execute_v3 API in the project introduction
- add English API documentation
- describe where problem definitions live
- fix broken link and mention English/Korean specs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862323aac88832e9b5231d66fa1ad2a