### PR TITLE
Change backend default port to 18651

### DIFF
--- a/Dockerfile.online-judge.backend
+++ b/Dockerfile.online-judge.backend
@@ -11,4 +11,4 @@ COPY online_judge_backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 COPY online_judge_backend ./online_judge_backend
-CMD ["uvicorn", "online_judge_backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "online_judge_backend.app.main:app", "--host", "0.0.0.0", "--port", "18651"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,7 +47,7 @@
    ```
 8. `online_judge_backend/app`로 이동하여 FastAPI 백엔드를 실행합니다.
    ```bash
-   uvicorn app.main:app --host 0.0.0.0 --port 8000
+   uvicorn app.main:app --host 0.0.0.0 --port 18651
    ```
 
 ## 프론트엔드 실행
@@ -68,7 +68,7 @@ python -m http.server 8080
 
 문제 정의는 `online_judge_backend/static/codeground-problems` 폴더의 JSON 파일로 관리됩니다. 각 파일에는 테스트 케이스와 제한 사항이 담겨 있으며 `/execute_v3`에서 사용됩니다.
 
-프론트엔드에는 API 주소를 입력할 수 있는 필드가 있습니다. 기본값은 `http://localhost:8000`으로 FastAPI 백엔드를 가리킵니다. 다른 서버를 지정하는 경우 CORS 설정이 되어 있어야 합니다. 추가 오리진은 `.env` 파일의 `CORS_ALLOW_ORIGINS` 변수(콤마 구분)를 통해 지정할 수 있습니다.
+프론트엔드에는 API 주소를 입력할 수 있는 필드가 있습니다. 기본값은 `http://localhost:18651`으로 FastAPI 백엔드를 가리킵니다. 다른 서버를 지정하는 경우 CORS 설정이 되어 있어야 합니다. 추가 오리진은 `.env` 파일의 `CORS_ALLOW_ORIGINS` 변수(콤마 구분)를 통해 지정할 수 있습니다.
 
 ## 사용법
 JWT 토큰을 입력한 뒤 언어와 코드를 작성하고 STDIN이 있다면 빈 줄로 구분된 블록 단위로 입력할 수 있습니다. 한 블록은 여러 줄을 포함할 수 있으며, 빈 줄이 나타날 때마다 다음 실행으로 인식됩니다. **실행!** 버튼을 누르면 각 블록에 대해 코드를 실행한 결과 배열을 돌려줍니다.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
    ```
 7. Start the FastAPI backend:
    ```bash
-   uvicorn online_judge_backend.app.main:app --host 0.0.0.0 --port 8000
+   uvicorn online_judge_backend.app.main:app --host 0.0.0.0 --port 18651
    ```
 
 ## Running the Frontend
@@ -75,7 +75,7 @@ Problem definitions are stored as JSON under
 `online_judge_backend/static/codeground-problems`. Each file lists the test cases
 and limits used by `/execute_v3`.
 
-The frontend includes a field to specify the API URL. The default is `http://localhost:8000`, which points to the FastAPI backend. If specifying a different server, make sure CORS settings are configured properly. Additional origins can be added via the `CORS_ALLOW_ORIGINS` variable in the `.env` file (comma-separated).
+The frontend includes a field to specify the API URL. The default is `http://localhost:18651`, which points to the FastAPI backend. If specifying a different server, make sure CORS settings are configured properly. Additional origins can be added via the `CORS_ALLOW_ORIGINS` variable in the `.env` file (comma-separated).
 
 ## Usage
 After entering a JWT token, select a language and write your code. If there is STDIN input, enter it as blocks separated by blank lines. Each block can contain multiple lines, and a new execution is triggered when a blank line is encountered. Press the **Execute!** button to receive an array of results, one per input block.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,6 +1,6 @@
 function getBaseUrl() {
   const url = document.getElementById("apiUrl").value.trim();
-  return url || "http://localhost:8000";
+  return url || "http://localhost:18651";
 }
 
 function sleep(ms) {

--- a/frontend/app_v2.js
+++ b/frontend/app_v2.js
@@ -2,7 +2,7 @@ let totalRuns = 1;
 
 function getBaseUrl() {
   const url = document.getElementById("apiUrl").value.trim();
-  return url || "http://localhost:8000";
+  return url || "http://localhost:18651";
 }
 
 function displayResults(data) {

--- a/frontend/app_v3.js
+++ b/frontend/app_v3.js
@@ -2,7 +2,7 @@ let totalRuns = 1;
 
 function getBaseUrl() {
   const url = document.getElementById("apiUrl").value.trim();
-  return url || "http://localhost:8000";
+  return url || "http://localhost:18651";
 }
 
 function displayRunResults(data) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,7 +18,7 @@
 
   <div class="form-group">
     <label for="apiUrl">API 엔드포인트 URL:</label>
-    <input id="apiUrl" type="text" value="http://localhost:8000">
+    <input id="apiUrl" type="text" value="http://localhost:18651">
   </div>
 
   <div class="form-group">

--- a/frontend/index_v2.html
+++ b/frontend/index_v2.html
@@ -18,7 +18,7 @@
 
   <div class="form-group">
     <label for="apiUrl">API 엔드포인트 URL:</label>
-    <input id="apiUrl" type="text" value="http://localhost:8000">
+    <input id="apiUrl" type="text" value="http://localhost:18651">
   </div>
 
   <div class="form-group">

--- a/frontend/index_v3.html
+++ b/frontend/index_v3.html
@@ -18,7 +18,7 @@
 
   <div class="form-group">
     <label for="apiUrl">API 엔드포인트 URL:</label>
-    <input id="apiUrl" type="text" value="http://localhost:8000">
+    <input id="apiUrl" type="text" value="http://localhost:18651">
   </div>
 
   <div class="form-group">

--- a/online_judge_backend/app/main.py
+++ b/online_judge_backend/app/main.py
@@ -36,6 +36,7 @@ origins = [
     "http://localhost:3000",
     "http://localhost:8080",
     "http://localhost:8000",
+    "http://localhost:18651",
 ]
 
 extra_origins = os.getenv("CORS_ALLOW_ORIGINS")

--- a/online_judge_backend/docs/API.ko.md
+++ b/online_judge_backend/docs/API.ko.md
@@ -53,7 +53,7 @@
 
 ### 예시
 ```bash
-curl -X POST http://localhost:8000/execute \
+curl -X POST http://localhost:18651/execute \
   -H 'Content-Type: application/json' \
   -d '{
     "language": "python",

--- a/online_judge_backend/docs/RabbitMQ.ko.md
+++ b/online_judge_backend/docs/RabbitMQ.ko.md
@@ -39,7 +39,7 @@ docker stop rabbitmq && docker rm rabbitmq
 예를 들어, EC2 인스턴스 5대가 있다면, 
 - RabbitMQ 서버용 EC2 인스턴스 1대
 
-- FastAPI 백엔드용 EC2 인스턴스 1대 (`online_judge_backend.app.main:app --host 0.0.0.0 --port 8000`)
+- FastAPI 백엔드용 EC2 인스턴스 1대 (`online_judge_backend.app.main:app --host 0.0.0.0 --port 18651`)
 
 - 그리고 나머지 3대가 각각 워커 프로세스를 실행 (`python -m app.worker`)
 


### PR DESCRIPTION
## Summary
- allow CORS for `http://localhost:18651`
- run backend on port `18651` in the dockerfile
- update frontend default API URL values
- document new default port in READMEs and docs

## Testing
- `pip install -r online_judge_backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625d709db4832e97ff42d4daa7860a