### PR TITLE
Improve grading status codes

### DIFF
--- a/frontend/app_v3.js
+++ b/frontend/app_v3.js
@@ -26,7 +26,14 @@ function displayRunResults(data) {
 
 function displayGradedResults(data) {
   const lines = data.results.map((r) => {
-    const status = r.passed ? "PASS" : "FAIL";
+    const statusMap = {
+      success: "PASS",
+      compile_error: "COMPILE ERROR",
+      wrong_output: "WRONG OUTPUT",
+      timeout: "TIMEOUT",
+      failure: "FAIL",
+    };
+    const status = statusMap[r.status] || r.status;
     return (
       `#${r.id} [${r.visibility}] ${status}\n` +
       `stdout: ${r.stdout}\n` +

--- a/online_judge_backend/docs/API.ko.md
+++ b/online_judge_backend/docs/API.ko.md
@@ -120,6 +120,8 @@ curl -X POST http://localhost:18651/execute \
 `requestId`는 `/ws/progress/{requestId}` WebSocket에 연결할 때 사용합니다. 서버는 각 테스트 케이스 결과를 순차적으로 전송하며 마지막 메시지에서 `type`이 `final`이면 채점이 완료된 것입니다.
 
 - `passed`가 `true`이면 해당 테스트 케이스를 통과한 것입니다.
+- `status`는 `success`, `compile_error`, `wrong_output`, `timeout`, `failure`
+  중 하나로 채점 결과를 세분화한 값입니다. `success`일 때만 `passed`가 `true`입니다.
 - `allPassed`가 `true`이면 모든 테스트 케이스를 통과했음을 의미합니다.
 
 ## WebSocket `/ws/progress/{request_id}`
@@ -199,31 +201,33 @@ JSON 메시지 스트림 형식은 `/execute_v2`를 보냈을 때와 `/execute_v
 	"problemId": "prob-004",
 	"allPassed": false,
 	"results": [
-		{
-			"id": 1,
-			"visibility": "public",
-			"passed": true,
-			"expected": "14",
-			"stdout": "14\n",
-			"stderr": "",
-			"exitCode": 0,
-			"duration": 13.35,
-			"memoryUsed": 588,
-			"timedOut": false
-		},
-		{
-			"id": 2,
-			"visibility": "hidden",
-			"passed": false,
-			"expected": "10",
-			"stdout": "10\n",
-			"stderr": "",
-			"exitCode": 0,
-			"duration": 13.24,
-			"memoryUsed": 616,
-			"timedOut": false
-		}
-	],
+                {
+                        "id": 1,
+                        "visibility": "public",
+                        "passed": true,
+                        "status": "success",
+                        "expected": "14",
+                        "stdout": "14\n",
+                        "stderr": "",
+                        "exitCode": 0,
+                        "duration": 13.35,
+                        "memoryUsed": 588,
+                        "timedOut": false
+                },
+                {
+                        "id": 2,
+                        "visibility": "hidden",
+                        "passed": false,
+                        "status": "timeout",
+                        "expected": "10",
+                        "stdout": "",
+                        "stderr": "",
+                        "exitCode": -9,
+                        "duration": 30001.0,
+                        "memoryUsed": 616,
+                        "timedOut": true
+                }
+        ],
 	"total": 8
 }
 ```


### PR DESCRIPTION
## Summary
- classify grading results into more detailed statuses
- show status in problem solution UI
- document new statuses in the API guide
- add timeout status

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68652b55df24832e92bf0588fb10211b