### PR TITLE
Add /execute_v4 endpoint

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 - Python, Java, C, C++ 코드를 실행
 - 지원하지 않는 언어는 **501 Not Implemented** 응답
-- 백엔드(`online_judge_backend` 폴더)는 FastAPI 기반 `/execute` API 외에도 `/execute_v2`, `/execute_v3` 엔드포인트를 제공하며 RabbitMQ로 작업을 워커에 전달합니다.
+- 백엔드(`online_judge_backend` 폴더)는 FastAPI 기반 `/execute` API 외에도 `/execute_v2`, `/execute_v3`, `/execute_v4` 엔드포인트를 제공하며 RabbitMQ로 작업을 워커에 전달합니다.
 - 워커는 `python -m online_judge_backend.app.worker` 명령으로 실행합니다.
 - 프론트엔드(`frontend` 폴더)는 백엔드를 사용할 수 있는 데모 웹 UI입니다.
 
@@ -62,11 +62,11 @@ python -m http.server 8080
 기존 `frontend/index.html`은 여전히 동기식 `/execute` 엔드포인트를 사용합
 니다. `frontend/index_v2.html` 페이지에서는 WebSocket으로 진행 상황을 받
 아오는 비동기 API 동작을 확인할 수 있습니다. 문제 기반 채점은
-`frontend/index_v3.html` 페이지에서 `/execute_v3` API를 통해 확인할 수 있으며, `/execute_v3` 역시 `/execute_v2`와 마찬가지로 진행 상황을 WebSocket으로 전송합니다.
+`frontend/index_v3.html` 페이지에서 `/execute_v3` API를 통해 확인할 수 있으며, `/execute_v3` 역시 `/execute_v2`와 마찬가지로 진행 상황을 WebSocket으로 전송합니다. `/execute_v4`는 동일하지만 `stdout`과 `stderr`를 클라이언트에 보내지 않습니다.
 
 클라이언트는 테스트 케이스 수를 미리 알 수 없으므로 각 `progress` 메시지에는 전체 개수를 나타내는 `total` 값이 포함됩니다. 테스트 케이스가 하나라도 실패하면 남은 케이스는 실행하지 않고 즉시 결과가 전송됩니다. `/execute_v3`의 HTTP 응답에는 `requestId`만 포함되며 최종 채점 결과는 WebSocket 메시지로 전달됩니다.
 
-문제 정의는 기본적으로 AWS S3 버킷에서 읽어오지만, AWS 관련 환경 변수가 비어 있거나 버킷에 연결할 수 없는 경우 `online_judge_backend/static` 폴더에 있는 JSON 파일을 사용합니다. 각 파일에는 테스트 케이스와 제한 사항이 담겨 있으며 `/execute_v3`에서 사용됩니다.
+문제 정의는 기본적으로 AWS S3 버킷에서 읽어오지만, AWS 관련 환경 변수가 비어 있거나 버킷에 연결할 수 없는 경우 `online_judge_backend/static` 폴더에 있는 JSON 파일을 사용합니다. 각 파일에는 테스트 케이스와 제한 사항이 담겨 있으며 `/execute_v3`와 `/execute_v4`에서 사용됩니다.
 
 프론트엔드에는 API 주소를 입력할 수 있는 필드가 있습니다. 기본값은 `http://localhost:18651`으로 FastAPI 백엔드를 가리킵니다. 다른 서버를 지정하는 경우 CORS 설정이 되어 있어야 합니다. 추가 오리진은 `.env` 파일의 `CORS_ALLOW_ORIGINS` 변수(콤마 구분)를 통해 지정할 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Executes Python, Java, C, and C++ code
 - Returns **501 Not Implemented** for unsupported languages
 - The backend (in the `online_judge_backend` folder) exposes `/execute` for synchronous
-  runs and `/execute_v2`/`/execute_v3` for asynchronous processing. Jobs are delivered
+  runs and `/execute_v2`/`/execute_v3`/`/execute_v4` for asynchronous processing. Jobs are delivered
   to workers via RabbitMQ.
 - Workers can be started with the command `python -m online_judge_backend.app.worker`.
 - The frontend (in the `frontend` folder) is a demo web UI that utilizes the backend.
@@ -62,7 +62,8 @@ Then visit `http://localhost:8080`.
 The original `frontend/index.html` still uses the synchronous `/execute`
 endpoint. The `frontend/index_v2.html` page demonstrates the asynchronous API
 that streams progress over WebSockets. Problem-based judging can also be
-tested with `frontend/index_v3.html`, which calls the `/execute_v3` API. The
+tested with `frontend/index_v3.html`, which calls the `/execute_v3` API. A variant
+`/execute_v4` works the same but omits `stdout` and `stderr` from the results. The
 `/execute_v3` endpoint streams judging progress in the same way as
 `/execute_v2`. Because the client does not know the number of test cases in
 advance, each progress message now includes a `total` field so the progress bar
@@ -75,7 +76,7 @@ Problem definitions are normally loaded from an AWS S3 bucket. If the AWS
 environment variables are not set or the bucket is unreachable, the backend
 falls back to the JSON files in `online_judge_backend/static`. See
 `online_judge_backend/.env.example` for the variables that configure the S3
-bucket and prefix used by `/execute_v3`.
+bucket and prefix used by `/execute_v3` and `/execute_v4`.
 
 The frontend includes a field to specify the API URL. The default is `http://localhost:18651`, which points to the FastAPI backend. If specifying a different server, make sure CORS settings are configured properly. Additional origins can be added via the `CORS_ALLOW_ORIGINS` variable in the `.env` file (comma-separated).
 

--- a/online_judge_backend/docs/API.md
+++ b/online_judge_backend/docs/API.md
@@ -5,6 +5,7 @@ This document describes the HTTP API provided by the backend. There are three ma
 - `POST /execute` &ndash; run code synchronously.
 - `POST /execute_v2` &ndash; run code asynchronously and stream progress through WebSockets.
 - `POST /execute_v3` &ndash; grade code against predefined problems. Progress is streamed as with `/execute_v2`.
+- `POST /execute_v4` &ndash; same as `/execute_v3` but omits `stdout` and `stderr` from responses.
 
 For websocket updates, connect to `/ws/progress/{requestId}` using the `requestId` returned by the `v2` or `v3` endpoints.
 
@@ -33,3 +34,8 @@ The HTTP response contains only a `requestId`. WebSocket messages include `progr
 Please refer to the `API.ko.md` for the specific JSON format.
 
 Each `progress` message contains `index`, `result` and `total` fields so the client can update progress bars.
+
+## POST `/execute_v4`
+
+Identical to `/execute_v3` but `stdout` and `stderr` fields are removed from
+the progress and final messages for security reasons.


### PR DESCRIPTION
## Summary
- add `/execute_v4` API that hides stdout/stderr
- support hiding of outputs in progress/final messages
- document the new endpoint in README and API docs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865f1ede83c832eae7f16b8607f1a22