### PR TITLE
Add execute_v4_public support in frontend

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -62,7 +62,7 @@ python -m http.server 8080
 기존 `frontend/index.html`은 여전히 동기식 `/execute` 엔드포인트를 사용합
 니다. `frontend/index_v2.html` 페이지에서는 WebSocket으로 진행 상황을 받
 아오는 비동기 API 동작을 확인할 수 있습니다. 문제 기반 채점은
-`frontend/index_v3.html` 페이지에서 `/execute_v3` API를 통해 확인할 수 있으며, `/execute_v3` 역시 `/execute_v2`와 마찬가지로 진행 상황을 WebSocket으로 전송합니다. `/execute_v4`는 동일하지만 `stdout`과 `stderr`를 클라이언트에 보내지 않습니다.
+`frontend/index_v3.html` 페이지에서 `/execute_v3` API를 통해 확인할 수 있으며, `/execute_v3` 역시 `/execute_v2`와 마찬가지로 진행 상황을 WebSocket으로 전송합니다. `/execute_v4`는 동일하지만 `stdout`과 `stderr`를 클라이언트에 보내지 않습니다. `/execute_v4_public`은 공개 테스트케이스만 실행합니다.
 
 클라이언트는 테스트 케이스 수를 미리 알 수 없으므로 각 `progress` 메시지에는 전체 개수를 나타내는 `total` 값이 포함됩니다. 테스트 케이스가 하나라도 실패하면 남은 케이스는 실행하지 않고 즉시 결과가 전송됩니다. `/execute_v3`의 HTTP 응답에는 `requestId`만 포함되며 최종 채점 결과는 WebSocket 메시지로 전달됩니다.
 

--- a/frontend/app_v4.js
+++ b/frontend/app_v4.js
@@ -133,3 +133,35 @@ document.getElementById("run").addEventListener("click", async () => {
 
   watchProgress(data.requestId);
 });
+
+document.getElementById("runPublic").addEventListener("click", async () => {
+  const lang = document.getElementById("lang").value;
+  const code = document.getElementById("code").value;
+  const problemId = document.getElementById("problemId").value.trim();
+  const token = document.getElementById("token").value.trim();
+
+  document.getElementById("stdout").textContent = "실행 중...";
+  document.getElementById("stderr").textContent = "";
+  document.getElementById("judgeMessage").textContent = "";
+  document.getElementById("metrics").textContent = "";
+  totalRuns = 1;
+  updateProgress(0);
+
+  const body = { language: lang, code, problemId, token: token || null };
+
+  const res = await fetch(`${getBaseUrl()}/execute_v4_public`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+
+  if (!res.ok) {
+    document.getElementById("stderr").textContent = data.error || data.detail ||
+      "Error";
+    document.getElementById("stdout").textContent = "";
+    return;
+  }
+
+  watchProgress(data.requestId);
+});

--- a/frontend/index_v4.html
+++ b/frontend/index_v4.html
@@ -37,6 +37,7 @@
   </div>
 
   <button id="run">실행!</button>
+  <button id="runPublic">실행! (공개 TC들만)</button>
 
   <h2>결과</h2>
   <div id="progressContainer" class="progress-container">

--- a/online_judge_backend/docs/API.ko.md
+++ b/online_judge_backend/docs/API.ko.md
@@ -1,7 +1,7 @@
 # Online Judge Backend REST API 명세서
 
 이 문서는 온라인 저지 백엔드에서 제공하는 HTTP API를 설명합니다. 기본적인 동기식
-`/execute` 엔드포인트 외에도 v2, v3, v4는 RabbitMQ 기반의 비동기식 API(`/execute_v2` + WebSocket 또는 `/execute_v3`/`/execute_v4` + WebSocket)를 제공합니다. `frontend/index_v2.html` 및 `frontend/index_v3.html`가 이 비동기 방식을 사용한 데모입니다.
+`/execute` 엔드포인트 외에도 v2, v3, v4는 RabbitMQ 기반의 비동기식 API(`/execute_v2` + WebSocket 또는 `/execute_v3`/`/execute_v4`/`/execute_v4_public` + WebSocket)를 제공합니다. `frontend/index_v2.html` 및 `frontend/index_v3.html`가 이 비동기 방식을 사용한 데모입니다.
 
 ## POST `/execute`
 
@@ -172,6 +172,7 @@ JSON 메시지 스트림 형식은 `/execute_v2`를 보냈을 때와 `/execute_v
 ```
 ### 진행 메시지 예시 (`/execute_v4`)
 `/execute_v4`는 `/execute_v3`와 동일하지만 `stdout`과 `stderr` 필드를 보내지 않습니다.
+`/execute_v4_public`은 공개 테스트케이스만 실행한다는 점을 제외하면 `/execute_v4`와 동일합니다.
 ```json
 {
   "type": "progress",
@@ -257,6 +258,7 @@ JSON 메시지 스트림 형식은 `/execute_v2`를 보냈을 때와 `/execute_v
 
 ### 최종 메시지 예시 (`/execute_v4`)
 `/execute_v4`의 결과 예시는 다음과 같이 `stdout`과 `stderr`가 없습니다.
+`/execute_v4_public`의 최종 메시지 형식도 동일하며 공개 테스트케이스만 포함됩니다.
 ```json
 {
         "type": "final",

--- a/online_judge_backend/docs/API.md
+++ b/online_judge_backend/docs/API.md
@@ -6,6 +6,7 @@ This document describes the HTTP API provided by the backend. There are three ma
 - `POST /execute_v2` &ndash; run code asynchronously and stream progress through WebSockets.
 - `POST /execute_v3` &ndash; grade code against predefined problems. Progress is streamed as with `/execute_v2`.
 - `POST /execute_v4` &ndash; same as `/execute_v3` but omits `stdout` and `stderr` from responses.
+- `POST /execute_v4_public` &ndash; identical to `/execute_v4` but only runs public test cases.
 
 For websocket updates, connect to `/ws/progress/{requestId}` using the `requestId` returned by the `v2` or `v3` endpoints.
 
@@ -39,3 +40,7 @@ Each `progress` message contains `index`, `result` and `total` fields so the cli
 
 Identical to `/execute_v3` but `stdout` and `stderr` fields are removed from
 the progress and final messages for security reasons.
+
+## POST `/execute_v4_public`
+
+Same as `/execute_v4` but only public test cases are executed.


### PR DESCRIPTION
## Summary
- allow running only public test cases via `/execute_v4_public`
- document new endpoint in API docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b396b357c832e80c23dbe3b161f11