### PR TITLE
Add Prometheus metrics logging

### DIFF
--- a/online_judge_backend/app/logging_middleware.py
+++ b/online_judge_backend/app/logging_middleware.py
@@ -1,0 +1,39 @@
+import logging
+from time import time
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from prometheus_client import Counter, Histogram, make_asgi_app
+
+# Basic logger setup
+logger = logging.getLogger("online_judge")
+logging.basicConfig(level=logging.INFO)
+
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "endpoint", "http_status"],
+)
+REQUEST_LATENCY = Histogram(
+    "http_request_latency_seconds",
+    "Latency of HTTP requests in seconds",
+    ["method", "endpoint"],
+)
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start_time = time()
+        response = await call_next(request)
+        process_time = time() - start_time
+        method = request.method
+        path = request.url.path
+        status = response.status_code
+
+        REQUEST_COUNT.labels(method, path, str(status)).inc()
+        REQUEST_LATENCY.labels(method, path).observe(process_time)
+        logger.info(
+            "%s %s %s %.3fs", method, path, status, process_time
+        )
+        return response
+
+# ASGI app exposing Prometheus metrics
+metrics_app = make_asgi_app()

--- a/online_judge_backend/app/main.py
+++ b/online_judge_backend/app/main.py
@@ -5,6 +5,8 @@ from typing import List, Dict, Set
 from enum import Enum
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Request
 from fastapi.middleware.cors import CORSMiddleware
+
+from .logging_middleware import LoggingMiddleware, metrics_app
 from pydantic import BaseModel
 from dotenv import load_dotenv
 from pathlib import Path
@@ -51,6 +53,8 @@ class ResultStatus(str, Enum):
     FAILURE = "failure"
 
 app = FastAPI()
+app.add_middleware(LoggingMiddleware)
+app.mount("/metrics", metrics_app)
 app.state.ws_connections: Dict[str, Set[WebSocket]] = {}
 app.state.progress_queue = None
 app.state.v3_meta: Dict[str, dict] = {}

--- a/online_judge_backend/app/worker.py
+++ b/online_judge_backend/app/worker.py
@@ -6,30 +6,40 @@ from pathlib import Path
 import time
 from dotenv import load_dotenv
 import aio_pika
+import logging
+from prometheus_client import Counter, Histogram, start_http_server
 
 # Load ../.env relative to this file so it works regardless of cwd
 env_path = Path(__file__).resolve().parents[1] / ".env"
 load_dotenv(dotenv_path=env_path, override=True)
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("worker")
+
+JOB_COUNT = Counter('worker_jobs_total', 'Total jobs processed', ['result'])
+JOB_DURATION = Histogram('worker_job_duration_seconds', 'Job processing time')
+
 from .executor import execute_code_multiple, SupportedLanguage
 
 
 async def main() -> None:
+    start_http_server(8001)
     url = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost/")
-    print(f"Connecting to RabbitMQ at {url} ...")
+    logger.info("Connecting to RabbitMQ at %s ...", url)
     connection = await aio_pika.connect_robust(url)
     channel = await connection.channel()
     queue = await channel.declare_queue("execute", durable=True)
 
-    print("Connected to RabbitMQ. Waiting for messages...")
+    logger.info("Connected to RabbitMQ. Waiting for messages...")
     async with queue.iterator() as queue_iter:
         async for message in queue_iter:
             async with message.process():
                 data = None
+                start_time = time.perf_counter()
                 try:
                     data = json.loads(message.body)
 
-                    print(f"Received message: {data}")
+                    logger.info("Received message: %s", data)
                     async def progress_cb(res, idx):
                         await channel.default_exchange.publish(
                             aio_pika.Message(
@@ -64,6 +74,7 @@ async def main() -> None:
                         ),
                         routing_key="progress",
                     )
+                    JOB_COUNT.labels(result="success").inc()
                 except Exception as e:
                     response = {"error": str(e)}
                     await channel.default_exchange.publish(
@@ -77,7 +88,8 @@ async def main() -> None:
                         ),
                         routing_key="progress",
                     )
-
+                    JOB_COUNT.labels(result="error").inc()
+                
                 await channel.default_exchange.publish(
                     aio_pika.Message(
                         body=json.dumps(response).encode(),
@@ -85,7 +97,8 @@ async def main() -> None:
                     ),
                     routing_key=message.reply_to,
                 )
-                print(f"Processed message: {data}")
+                JOB_DURATION.observe(time.perf_counter() - start_time)
+                logger.info("Processed message: %s", data)
 
 
 if __name__ == "__main__":

--- a/online_judge_backend/requirements.txt
+++ b/online_judge_backend/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 psutil
 aio_pika
 aioboto3
+prometheus-client


### PR DESCRIPTION
## Summary
- add prometheus-client to backend requirements
- create new `logging_middleware.py` for FastAPI request metrics
- mount middleware and /metrics endpoint in `main.py`
- instrument worker with Prometheus counters and histograms

## Testing
- `python -m py_compile online_judge_backend/app/*.py`
- `python -m online_judge_backend.app.main` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6870b6e8bdcc832e9127e4a1a1ab06b3